### PR TITLE
docs(OpenAI API): document base_url with multi-model gateway example

### DIFF
--- a/docs/12 - OpenAI API.md
+++ b/docs/12 - OpenAI API.md
@@ -532,6 +532,23 @@ response = client.chat.completions.create(
 print(response.choices[0].message.content)
 ```
 
+The same `base_url` / `OPENAI_API_BASE` pattern works with any OpenAI-compatible endpoint. For example, a multi-model gateway such as [DaoXE](https://daoxe.com):
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="your-daoxe-api-key",  # key issued by that endpoint
+    base_url="https://api.daoxe.com/v1",
+)
+
+response = client.chat.completions.create(
+    model="gpt-4o-mini",  # use a model ID the endpoint actually serves
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+print(response.choices[0].message.content)
+```
+
 With the [official Node.js openai client](https://github.com/openai/openai-node) (v4.x):
 
 ```js


### PR DESCRIPTION
## Summary
The third-party client setup section already shows `OPENAI_API_BASE` / `base_url` for the local TextGen API. This PR adds a short note that the **same pattern** works with any OpenAI-compatible endpoint, using [DaoXE](https://daoxe.com) as one concrete multi-model gateway example (`https://api.daoxe.com/v1`).

Docs only — no runtime code changes.

## Why
Users often switch between local OpenAI-compatible servers and cloud multi-model gateways with the same client code. Documenting that interchangeability makes the existing `base_url` guidance clearer.

## Changes
- Extended the Python OpenAI client example in `docs/12 - OpenAI API.md`
- Optional example only; no product numbers invented
- Clean base URL (no UTM)

## Test plan
- [ ] Docs page renders cleanly
- [ ] Parallel-requests and other examples still present
- [ ] DaoXE is clearly optional / one example among many

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>