### PR TITLE
Don't treat a trailing bare number as an unfinished list marker

### DIFF
--- a/modules/html_generator.py
+++ b/modules/html_generator.py
@@ -343,12 +343,11 @@ def process_markdown_content(string):
 
     # Unfinished list, like "\n1.". A |delete| string is added and then
     # removed to force a <ol> or <ul> to be generated instead of a <p>.
-    list_item_pattern = r'(\n\d+\.?|\n\s*[-*+]\s*([*_~]{1,3})?)$'
+    # The dot is required: a trailing line holding only digits is a number the
+    # model wrote, not a list marker, and treating it as one swallowed it.
+    list_item_pattern = r'(\n\d+\.|\n\s*[-*+]\s*([*_~]{1,3})?)$'
     if re.search(list_item_pattern, result):
         delete_str = '|delete|'
-
-        if re.search(r'(\d+\.?)$', result) and not result.endswith('.'):
-            result += '.'
 
         # Add the delete string after the list item
         result = re.sub(list_item_pattern, r'\g<1> ' + delete_str, result)


### PR DESCRIPTION
Fixes #7535.

### What happens

The reporter saw a final line of `7` render as `7.`. It is actually worse than that: the number is not given a dot, it is **consumed into an empty list item and disappears from the text**.

On current `main`:

```
input : 'Xenial brave calm mirror daring euphoria xylophone\n7'
output: <p>Xenial brave calm mirror daring euphoria xylophone<br /><ol start="7"><li></li></ol></p>

input : 'Released in\n1999'
output: <p>Released in<br /><ol start="1999"><li></li></ol></p>

input : 'Final score\n100'
output: <p>Final score<br /><ol start="100"><li></li></ol></p>
```

The digits become the `start` attribute of an `<ol>` whose single `<li>` is empty. Any reply whose last line is a bare number, a word count, a year, a total, a score, hits this.

### Why

`process_markdown_content` has an unfinished-list branch so that a partial `\n1.` arriving mid-stream renders as a list rather than flickering through a paragraph first. The pattern made the dot optional:

```python
list_item_pattern = r'(\n\d+\.?|\n\s*[-*+]\s*([*_~]{1,3})?)$'
```

so `\n7` matched as well, and the branch below then appended a literal dot to force the list:

```python
if re.search(r'(\d+\.?)$', result) and not result.endswith('.'):
    result += '.'
```

### Change

Require the dot. A line of bare digits is a number the model wrote, not a list marker: markdown needs `7.` or `7)` to start an ordered list, so there is nothing to anticipate.

With the dot required, the explicit `result += '.'` can no longer fire, so it is removed as well. That branch only ran when `list_item_pattern` matched; brute-forcing all 94 endings that match the new pattern (`\n<digits>.` and every bullet/whitespace/emphasis combination) gives 0 that would still satisfy `re.search(r'(\d+\.?)$', result) and not result.endswith('.')`, since the numeric branch now always ends in a dot and the bullet branch never ends in a digit.

### Verification

Ran `process_markdown_content` before and after over the reported case plus other trailing-number shapes and the list behaviours that must not regress:

```
##### BEFORE (upstream main)
  issue #7535            NUMBER EATEN   <p>...xylophone<br /> <ol start="7"> <li></li> </ol>
  word count             NUMBER EATEN   <p>The answer is<br /> <ol start="42"> <li></li> </ol>
  trailing year          NUMBER EATEN   <p>Released in<br /> <ol start="1999"> <li></li> </ol>
  score line             NUMBER EATEN   <p>Final score<br /> <ol start="100"> <li></li> </ol>
  -> 4 case(s) with the number destroyed

##### AFTER
  issue #7535            ok             <p>...xylophone<br /> <p>7</p> </p>
  word count             ok             <p>The answer is<br /> <p>42</p> </p>
  trailing year          ok             <p>Released in<br /> <p>1999</p> </p>
  score line             ok             <p>Final score<br /> <p>100</p> </p>
  -> 0 case(s) with the number destroyed
```

List rendering is byte-identical before and after on all six list cases checked: a real ordered list, a trailing `1.` marker, trailing `-`, trailing `* `, trailing `- **`, and a bulleted list.

### The one trade-off

While streaming, a `7` that is about to become `7.` now renders inside the paragraph for the frame before the dot arrives, instead of being pre-emptively promoted to a list. That is one frame of a list appearing slightly later, against a completed message permanently losing a number it ended with, so it seemed the right way round. Happy to gate it on streaming instead if you would rather keep the anticipation.

I did not add a test: the repo has no test suite or test job, and adding one for this seemed like more scope than the fix deserves. The before/after script is a few lines if it is useful to anyone.
