### PR TITLE
Stop the Perplexity Stride slider shadowing the Training one

### DIFF
--- a/modules/training.py
+++ b/modules/training.py
@@ -136,7 +136,7 @@ def create_ui():
                     evaluate_text_file = gr.Dropdown(choices=['wikitext', 'ptb', 'ptb_new'] + utils.get_datasets(str(shared.user_data_dir / 'training/datasets'), 'txt')[1:], value='wikitext', label='Input dataset', info=f'The raw text file on which the model will be evaluated. The first options are automatically downloaded: wikitext, ptb, and ptb_new. The next options are your local text files under {shared.user_data_dir}/training/datasets.', interactive=not mu)
                     with gr.Row():
                         with gr.Column():
-                            stride_length = gr.Slider(label='Stride', minimum=0, maximum=32768, value=512, step=256, info='Used to make the evaluation faster at the cost of accuracy. 1 = slowest but most accurate. 512 is a common value.')
+                            eval_stride_length = gr.Slider(label='Stride', minimum=0, maximum=32768, value=512, step=256, info='Used to make the evaluation faster at the cost of accuracy. 1 = slowest but most accurate. 512 is a common value.')
 
                         with gr.Column():
                             max_length = gr.Number(label='max_length', precision=0, step=256, value=0, info='The context for each evaluation. If set to 0, the maximum context length for the model will be used.')
@@ -165,12 +165,12 @@ def create_ui():
     # Evaluation events. For some reason, the interrupt event
     # doesn't work with the .then() syntax, so I write them one
     # by one in this ugly but functional way.
-    ev = start_evaluation.click(calculate_perplexity, [models, evaluate_text_file, stride_length, max_length], evaluation_log, show_progress=False)
+    ev = start_evaluation.click(calculate_perplexity, [models, evaluate_text_file, eval_stride_length, max_length], evaluation_log, show_progress=False)
     ev.then(generate_markdown_table, None, evaluation_table, show_progress=False)
 
     ev_cur = start_current_evaluation.click(
         lambda: ['current model'], None, tmp).then(
-        calculate_perplexity, [tmp, evaluate_text_file, stride_length, max_length], evaluation_log, show_progress=False)
+        calculate_perplexity, [tmp, evaluate_text_file, eval_stride_length, max_length], evaluation_log, show_progress=False)
 
     ev_cur.then(generate_markdown_table, None, evaluation_table, show_progress=False)
 


### PR DESCRIPTION
## Problem

`create_ui()` binds the local name `stride_length` twice:

```python
# line 118, Text Dataset tab: chunk overlap for training
stride_length = gr.Slider(label='Stride Length', minimum=0, maximum=2048, value=256, step=32, ...)

# line 139, Perplexity evaluation tab: eval speed/accuracy tradeoff
stride_length = gr.Slider(label='Stride', minimum=0, maximum=32768, value=512, step=256, ...)
```

`all_params` is built at line 158, after both, so the name resolves to the **evaluation** slider. Gradio wires by component object rather than by name, so `do_train` is handed the evaluation slider and the Training tab's own "Stride Length" slider is connected to nothing at all.

On stock defaults, with the user touching nothing, that aborts text-dataset LoRA training before it starts:

```
cutoff_len    = 512     Training tab "Cutoff Length"
stride_length = 512     Perplexity tab "Stride", via the shadowing
step = cutoff_len - stride = 0
-> "Error: stride length must be smaller than cutoff length."
```

The values actually on screen are Cutoff Length 512 and Stride Length 256, which is a perfectly valid pair (`step = 256`). So the error contradicts what the user is looking at, and moving the slider the message is complaining about does nothing.

`all_params` feeds two more things (`do_copy_params` at line 160 and `do_train` at line 161), so the same shadowing has two further effects:

- `training_parameters.json` records the **evaluation** slider's value under `stride_length`.
- "Copy parameters from" writes a saved LoRA's stride back into the **evaluation** slider instead of the training one.

## Fix

Rename the evaluation slider to `eval_stride_length`, and move its two `calculate_perplexity` wirings (lines 168 and 173) with it. Three lines, no behaviour change to evaluation.

## Verification

There is no test suite in this repo and no CI test job, so no test is added. What was checked instead, on CPU:

**1. Which component object each callback actually receives.** `create_ui()` was instantiated for real inside a `gr.Blocks()`, spying on `gr.Button.click` to capture the exact input lists. Two unrelated things had to be accommodated to get the module to import here, neither touching this code path: the optional `ddgs` import, and `gradio.themes.Base.set`, which the installed gradio 6.9.0 rejects some of this repo's theme kwargs on.

```
BEFORE
  do_train stride_length arg (PARAMETERS[27]): label='Stride' value=512 max=32768
  calculate_perplexity stride arg:             label='Stride' value=512 max=32768
  SAME OBJECT? True

    'Cutoff Length'  value=   512 max=  4096  reaches do_train=False
    'Stride Length'  value=   256 max=  2048  reaches do_train=False     <- dead
    'Stride'         value=   512 max= 32768  reaches do_train=True      <- wrong one

AFTER
  do_train stride_length arg:  label='Stride Length' value=256 max=2048
  perplexity stride arg:       label='Stride' value=512 max=32768
  SAME OBJECT? False

  stock defaults: cutoff_len=512 stride=256 -> step=256 -> training proceeds
```

**2. The consequence, through the real guard at lines 404 to 408.** Before: `step = 512 - 512 = 0`, so `if step <= 0` returns the error. After: `step = 512 - 256 = 256`, so it proceeds.

**3. Static confirmation** that this is the shadowing and not something else: parsing `create_ui` with `ast` shows `stride_length` assigned at lines 118 and 139, and `all_params` built at line 158, after both.

Evaluation is unaffected: the same component still reaches `calculate_perplexity`, verified above, and its default and range are unchanged.
