### PR TITLE
Parse the ExLlamaV3 sampler priority when it is a string

### DIFF
--- a/modules/exllamav3.py
+++ b/modules/exllamav3.py
@@ -352,7 +352,14 @@ class Exllamav3Model:
             }
 
             default_priority = ['repetition_penalty', 'presence_frequency_penalty', 'top_k', 'top_p', 'min_p', 'temperature']
-            sampler_priority = list(state.get('sampler_priority') or default_priority)
+            sampler_priority = state.get('sampler_priority') or default_priority
+            if isinstance(sampler_priority, str):
+                # Presets and --sampler-priority hold this as a newline-separated
+                # string, and list() on a string gives one entry per character, so
+                # no sampler name ever matched and the order was left untouched.
+                sampler_priority = [x.strip() for x in sampler_priority.replace('\n', ',').split(',') if x.strip()]
+            else:
+                sampler_priority = list(sampler_priority)
 
             if state['temperature_last'] and 'temperature' in sampler_priority:
                 sampler_priority.append(sampler_priority.pop(sampler_priority.index('temperature')))


### PR DESCRIPTION
## The bug

With the ExLlamaV3 (native) loader, "Sampler priority" and the `temperature_last` checkbox have no effect. `modules/exllamav3.py` read the order with:

```python
sampler_priority = list(state.get('sampler_priority') or default_priority)
```

`state['sampler_priority']` is a newline-separated **string** in every default path:

- `modules/presets.py` defines it as a string
- `modules/shared.py` declares `--sampler-priority` as `type=str`
- `modules/api/typing.py` defaults the API field to that same string

`list()` on a string returns one entry per character, so `sampler_priority` became `['r', 'e', 'p', 'e', ...]` (251 entries). No nickname was ever found, `custom_sort_key` returned `-1` for every sampler, the stable sort left the insertion order untouched, and the guard on the next line, `'temperature' in sampler_priority`, was False as well, so `temperature_last` was skipped too. Nothing is logged.

This is not limited to users who change the setting. Out of the box the shipped order places `temperature` third, and the loader ran it last.

## Evidence

Driving the ordering block sliced straight out of `modules/exllamav3.py` (lines 344 to 372), with the shipped default read out of `modules/presets.py`, and stub sampler objects named as the real ones:

```
A  user asks for temperature FIRST, in the shipped STRING form
     ['SS_RepP', 'SS_PresFreqP', 'SS_TopK', 'SS_TopP', 'SS_MinP', 'SS_Temperature']
B  identical request, already a LIST (what the code assumes)
     ['SS_Temperature', 'SS_TopK', 'SS_TopP', 'SS_MinP', 'SS_RepP', 'SS_PresFreqP']

E  OUT-OF-THE-BOX default STRING, temperature_last = False
     ['SS_RepP', 'SS_PresFreqP', 'SS_TopK', 'SS_TopP', 'SS_MinP', 'SS_Temperature']
F  same value as a LIST (what the code intends)
     ['SS_RepP', 'SS_PresFreqP', 'SS_Temperature', 'SS_TopK', 'SS_TopP', 'SS_MinP']
```

A vs B and E vs F are the defect: the same requested order gives a different sampler stack purely from the value's Python type, and the string form, which is the shipped one, is the ignored one.

After this change all three comparisons agree:

```
A == B (string honoured)?             True
C == D (default + temperature_last)?  True
E == F (out-of-the-box default)?      True
```

## The fix

Normalise the string before use, which the other two backends already do. `modules/llama_cpp_server.py` does `samplers.split("\n") if isinstance(samplers, str) else samplers`, and `modules/text_generation.py` does the comma-and-newline form. This reuses the latter, because it yields stripped names and the comparisons in `exllamav3.py` do not strip.

`list()` is kept on the non-string branch so the later `temperature_last` reorder does not mutate the caller's list, which was the reason for the original `list()` call.

## Checks

The repo has no test suite, so there is no regression test to add here. What was checked instead: the before and after runs above, driven from the live source rather than a retyped copy; the module still compiles; and `pycodestyle --max-line-length=120 --ignore=E402,E501,E722` (the `setup.cfg` settings) reports the same four pre-existing E704 findings before and after, so no new lint. The longest added line is 115 characters.
