### PR TITLE
Fix attachments being lost when "Start reply with" is used

### DIFF
--- a/modules/chat.py
+++ b/modules/chat.py
@@ -1746,7 +1746,9 @@ def send_dummy_message(text, state):
     history = state['history']
 
     # Handle both dict and string inputs
+    files = []
     if isinstance(text, dict):
+        files = text.get('files', [])
         text = text['text']
 
     # Initialize metadata if not present
@@ -1754,6 +1756,10 @@ def send_dummy_message(text, state):
         history['metadata'] = {}
 
     row_idx = len(history['internal'])
+
+    for file_path in files:
+        add_message_attachment(history, row_idx, file_path, is_user=True)
+
     history['visible'].append([html.escape(text), ''])
     history['internal'].append([apply_extensions('input', text, state, is_chat=True), ''])
     update_message_metadata(history['metadata'], "user", row_idx, timestamp=get_current_timestamp())


### PR DESCRIPTION
## The issue:

When the "Start reply with" field is non-empty, any uploaded attachments
never be sent to the model.
Since `send_dummy_message()` only extracts the `text` key from the multimodal textbox
input and silently discards the `file` key.

This is a leftover from the fix for #7033, which added dict input handling to
`send_dummy_message()` but only kept the text part.

## Fix:

In `send_dummy_message()`, read the `files` list from the dict input and store
each file via `add_message_attachment()` before appending the message to the
history, just mirroring what the normal generation path does.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/textgen/wiki/Contributing-guidelines).
