### PR TITLE
Fix: Continue crashes with jinja UndefinedError when a single message fills the context

### DIFF
--- a/modules/chat.py
+++ b/modules/chat.py
@@ -588,6 +588,14 @@ def generate_chat_prompt(user_input, state, **kwargs):
                 messages[-1]["content"] = "fake assistant message replace me"
                 messages.append({"role": "assistant", "content": "this will get deleted"})
 
+            if not messages:
+                # Context truncation can pop the only history message before
+                # this continuation slice runs, leaving nothing to render.
+                raise ValueError(
+                    "Cannot continue: no messages remain after context truncation. "
+                    "Increase ctx-size or shorten the input."
+                )
+
         if state['mode'] == 'chat-instruct':
             add_generation_prompt = _continue and not thinking_only_partial
         elif thinking_only_partial:


### PR DESCRIPTION
## Summary

Fixes #7629.

`generate_chat_prompt()`'s truncation loop pops messages from the outer `messages` list, while `make_prompt()`'s `_continue` branch independently slices its own local copy of that list (`messages = messages[:-1]`) to drop the in-progress assistant turn before re-rendering.

When the chat history is a single oversized user message plus its (already truncated) assistant reply, these two views desync:

1. The truncation loop sees `len(messages) == 2` and pops the user message (index 0), leaving only the assistant message.
2. It calls `make_prompt(messages)` again with that single-element list.
3. Inside `make_prompt`, the `_continue` branch slices `messages[:-1]`, which is now the *empty* list, since the assistant message was the only one left.
4. That empty list is handed straight to the Jinja renderer. Templates that index `messages[0]` directly (a very common pattern, e.g. Llama 3 style templates) raise `jinja2.exceptions.UndefinedError: list object has no element 0` — an unhandled crash deep inside template rendering, with no useful message for the user.

## Fix

Add a guard right after the `_continue` slicing in `make_prompt()`: if no messages remain at that point, raise a clear `ValueError` instead of letting the renderer fail on an empty list. This turns an opaque, unhandled Jinja crash into a predictable, user-facing error, consistent with the existing `raise ValueError` used a few lines below for the "input too long to truncate" case.

## Verification

Confirmed by isolating and calling `modules.chat.generate_chat_prompt()` directly (no GPU/model required):

- **Before the fix**, reproducing the reported scenario (single large user message + assistant reply that together exceed the truncation length, `_continue=True`, and a template that indexes `messages[0]`) raises the exact reported error: `jinja2.exceptions.UndefinedError: list object has no element 0`.
- **After the fix**, the same scenario raises a clear `ValueError: Cannot continue: no messages remain after context truncation. Increase ctx-size or shorten the input.` instead.
- Verified the unaffected paths still behave the same: a normal `_continue=True` call that doesn't hit truncation still renders correctly, and a fresh (non-continue) generation is unaffected.

I don't have a way to run the full Gradio app end-to-end in this environment (no GPU/GGUF backend available), so I verified directly against `generate_chat_prompt`/`make_prompt`, which contain the entire code path implicated in the traceback in #7629.

## Test plan

- [x] Reproduced the exact crash from #7629 against `modules.chat.generate_chat_prompt()` with a template that indexes `messages[0]`, confirmed it raises `jinja2.exceptions.UndefinedError: list object has no element 0` before the fix
- [x] Confirmed it raises a clear `ValueError` after the fix, in the same scenario
- [x] Confirmed normal `_continue=True` (no truncation) still renders the expected prompt
- [x] Confirmed a fresh, non-continue generation is unaffected