### PR TITLE
Fix generation interrupt propagation

### DIFF
--- a/modules/text_generation.py
+++ b/modules/text_generation.py
@@ -500,7 +500,6 @@ def generate_reply_HF(question, original_question, state, stopping_strings=None,
         original_tokens = len(original_input_ids[0])
         new_tokens = len(output) - (original_tokens if not shared.is_seq2seq else 0)
         logger.info(f'Output generated in {(t1-t0):.2f} seconds ({new_tokens/(t1-t0):.2f} tokens/s, {new_tokens} tokens, context {original_tokens}, seed {seed})')
-        return
 
 
 def generate_reply_custom(question, original_question, state, stopping_strings=None, is_chat=False):
@@ -539,7 +538,6 @@ def generate_reply_custom(question, original_question, state, stopping_strings=N
             new_tokens = len(encode(original_question + reply)[0]) - original_tokens
 
         logger.info(f'Output generated in {(t1-t0):.2f} seconds ({new_tokens/(t1-t0):.2f} tokens/s, {new_tokens} tokens, context {original_tokens}, seed {state["seed"]})')
-        return
 
 
 def print_prompt(prompt, max_chars=-1):


### PR DESCRIPTION
## Checklist

- [x] I have read the [Contributing guidelines](https://github.com/oobabooga/textgen/wiki/Contributing-guidelines).

## Description

Remove the explicit `return` statements from the `finally` blocks in the Hugging Face and custom generation paths.

A `return` executed from a `finally` block overrides a pending exception. In these generator functions, that could turn an interruption such as `KeyboardInterrupt` into normal generator completion. Reaching the end of the function already provides the same behavior during normal completion, while omitting the explicit `return` allows pending interruptions to propagate after generation statistics are logged.

Fixes #7438.

## Validation

- `python -m compileall -q modules/text_generation.py`
- verified normal generator completion and `KeyboardInterrupt` propagation with a focused reproduction
- `git diff --check`